### PR TITLE
remove city.id field

### DIFF
--- a/index.html
+++ b/index.html
@@ -2070,7 +2070,6 @@
               <tr><td>career_categories<br>.id</td><td> </td><td>integer </td><td>searchable facetable</td><td>CC</td><td><a class="target" data-toggle="tab" title="jobs" href="#jobs">J</a><a class="target" data-toggle="tab" title="training" href="#training">T</a></td></tr>
               <tr><td>career_categories<br>.name</td><td>Link for <a href="http://reliefweb.int/book/taxonomy-descriptions#careercategory">values</a></td><td>string </td><td>searchable facetable exact</td><td> </td><td><a class="target" data-toggle="tab" title="jobs" href="#jobs">J</a><a class="target" data-toggle="tab" title="training" href="#training">T</a></td></tr>
               <tr><td>city</td><td>defaults to city.name</td><td>array</td><td></td><td> </td><td><a class="target" data-toggle="tab" title="jobs" href="#jobs">J</a><a class="target" data-toggle="tab" title="training" href="#training">T</a></td></tr>
-              <tr><td>city.id</td><td> </td><td>integer </td><td>searchable facetable</td><td> </td><td><a class="target" data-toggle="tab" title="jobs" href="#jobs">J</a><a class="target" data-toggle="tab" title="training" href="#training">T</a></td></tr>
               <tr><td>city.name</td><td> </td><td>string </td><td>searchable facetable exact</td><td> </td><td><a class="target" data-toggle="tab" title="jobs" href="#jobs">J</a><a class="target" data-toggle="tab" title="training" href="#training">T</a></td></tr>
               <tr><td>content_type</td><td>Content types published from this source</td><td>array </td><td>sortable searchable</td><td> </td><td><a class="target" data-toggle="tab" title="sources" href="#sources">S</a></td></tr>
               <tr><td>country </td><td>defaults to country.name</td><td>array </td><td></td><td> </td><td><a class="target" data-toggle="tab" title="reports" href="#reports">R</a><a class="target" data-toggle="tab" title="jobs" href="#jobs">J</a><a class="target" data-toggle="tab" title="training" href="#training">T</a><a class="target" data-toggle="tab" title="disasters" href="#disasters">D</a><a class="target" data-toggle="tab" title="sources" href="#sources">S</a></td></tr>
@@ -2375,7 +2374,6 @@
               <tr><td>career_categories<br>.id</td><td>Id for career categories used by ReliefWeb </td><td>integer </td><td>searchable facetable</td><td>CC</td><td> </td></tr>
               <tr><td>career_categories<br>.name</td><td>Link for <a href="http://reliefweb.int/book/taxonomy-descriptions#careercategory">values</a></td><td>string </td><td>searchable facetable exact</td><td> </td><td> </td></tr>
               <tr><td>city</td><td>Shortcut for city - defaults to city.name</td><td>array </td><td></td><td> </td><td> </td></tr>
-              <tr><td>city.id</td><td>Id of city used by ReliefWeb </td><td>integer </td><td>searchable facetable</td><td> </td><td> </td></tr>
               <tr><td>city.name</td><td>Name of city in English</td><td>string </td><td>searchable facetable exact</td><td> </td><td> </td></tr>
               <tr><td>country </td><td>Shortcut for country - defaults to country.name</td><td>array </td><td></td><td> </td><td><strong>query</strong>: <em>analysis</em> <em>latest</em></td></tr>
               <tr><td>country.id </td><td>Id for country used by ReliefWeb </td><td>integer </td><td>searchable facetable</td><td>C</td><td> </td></tr>
@@ -2431,7 +2429,6 @@
               <tr><td>career_categories<br>.id</td><td>Id for career categories used by ReliefWeb </td><td>integer </td><td>searchable facetable</td><td>CC</td><td> </td></tr>
               <tr><td>career_categories<br>.name</td><td>Link for <a href="http://reliefweb.int/book/taxonomy-descriptions#careercategory">values</a></td><td>string </td><td>searchable facetable exact</td><td> </td><td> </td></tr>
               <tr><td>city</td><td>Shortcut for city - defaults to city.name</td><td>array </td><td></td><td> </td><td> </td></tr>
-              <tr><td>city.id</td><td>Id of city used by ReliefWeb </td><td>integer </td><td>searchable facetable</td><td> </td><td> </td></tr>
               <tr><td>city.name</td><td>Name of city in English</td><td>string </td><td>searchable facetable exact</td><td> </td><td> </td></tr>
               <tr><td>cost</td><td><code>free</code> or <code>fee-based</code></td><td>string </td><td>searchable facetable</td><td> </td><td> </td></tr>
               <tr><td>country </td><td>Shortcut for country - defaults to country.name</td><td>array </td><td></td><td> </td><td><strong>query</strong>: <em>analysis</em> <em>latest</em></td></tr>


### PR DESCRIPTION
Cities on the site are no longer to be managed as a taxonomy. The city.id field will no longer hold content, so removing it from the docs.