### PR TITLE
chore: encourage changing appname parameter from default

### DIFF
--- a/_meta/api-use.html
+++ b/_meta/api-use.html
@@ -21,10 +21,11 @@ order: 70
     <p>or as a body to a POST request:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "limit": 2
 }
 </pre>
@@ -33,12 +34,13 @@ order: 70
   </dd>
 </dl>
 
+<p>Please use the <a href="/parameters#appname">appname</a> parameter. At some stage we may make this obligatory, so do start using now. Please use an email address where we can contact you or a ReliefWeb username. The <a href="https://reliefweb.int/search/converter">search converter</a> tool will add your ReliefWeb username automatically if you are logged in.</p>
 <p>There are very simple client libraries for <a href="https://github.com/reliefweb/api-php-client">PHP</a> and <a href="https://github.com/reliefweb/api-go-client">Golang</a>. Please use them!</p>
 
 <p>GET requests can be made directly in a browser. In Firefox the resulting JSON should be presented clearly, there is a <a href="https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc">browser extension</a> for Brave, Chromium, etc.</p>
 
 <p>Post requests can be made via the editable textboxes in this documentation, or, from a command line, with a tool like <a href="https://curl.haxx.se/"><code>curl</code></a>:</p>
 
-<pre><code>curl -POST 'https://api.reliefweb.int/v1/reports?appname=apidoc' -d '{"limit": 2}'</code></pre>
+<pre><code>curl -POST 'https://api.reliefweb.int/v1/reports' -d '{"appname": "apidoc", "limit": 2}'</code></pre>
 
 <p>When dealing with JSON format for the post requests, a misplaced comma can be difficult to spot. To troubleshoot the error <code class="error">Invalid request body. It must be a valid json object.</code>, validators like <a href="http://jsonlint.com">JSONlint</a> can save a lot of time.</p>

--- a/_meta/api-use.html
+++ b/_meta/api-use.html
@@ -15,13 +15,13 @@ order: 70
     <p>Parameters can be passed in the query of a GET request:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&limit=2</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&limit=2</code></pre></div>
     </div>
 
     <p>or as a body to a POST request:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -40,6 +40,6 @@ order: 70
 
 <p>Post requests can be made via the editable textboxes in this documentation, or, from a command line, with a tool like <a href="https://curl.haxx.se/"><code>curl</code></a>:</p>
 
-<pre><code>curl -POST 'https://api.reliefweb.int/v1/reports?appname=apidoc' -d '{"limit": 2}'</code></pre>
+<pre><code>curl -POST 'https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME' -d '{"limit": 2}'</code></pre>
 
 <p>When dealing with JSON format for the post requests, a misplaced comma can be difficult to spot. To troubleshoot the error <code class="error">Invalid request body. It must be a valid json object.</code>, validators like <a href="http://jsonlint.com">JSONlint</a> can save a lot of time.</p>

--- a/_meta/api-use.html
+++ b/_meta/api-use.html
@@ -21,11 +21,10 @@ order: 70
     <p>or as a body to a POST request:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "limit": 2
 }
 </pre>
@@ -34,13 +33,13 @@ order: 70
   </dd>
 </dl>
 
-<p>Please use the <a href="/parameters#appname">appname</a> parameter. At some stage we may make this obligatory, so do start using now. Please use an email address where we can contact you or a ReliefWeb username. The <a href="https://reliefweb.int/search/converter">search converter</a> tool will add your ReliefWeb username automatically if you are logged in.</p>
+<p>Please use the <a href="/parameters#appname">appname</a> parameter. At some stage we may make this obligatory, so do start using now. Please use a domain name or an app name.</p>
 <p>There are very simple client libraries for <a href="https://github.com/reliefweb/api-php-client">PHP</a> and <a href="https://github.com/reliefweb/api-go-client">Golang</a>. Please use them!</p>
 
 <p>GET requests can be made directly in a browser. In Firefox the resulting JSON should be presented clearly, there is a <a href="https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc">browser extension</a> for Brave, Chromium, etc.</p>
 
 <p>Post requests can be made via the editable textboxes in this documentation, or, from a command line, with a tool like <a href="https://curl.haxx.se/"><code>curl</code></a>:</p>
 
-<pre><code>curl -POST 'https://api.reliefweb.int/v1/reports' -d '{"appname": "apidoc", "limit": 2}'</code></pre>
+<pre><code>curl -POST 'https://api.reliefweb.int/v1/reports?appname=apidoc' -d '{"limit": 2}'</code></pre>
 
 <p>When dealing with JSON format for the post requests, a misplaced comma can be difficult to spot. To troubleshoot the error <code class="error">Invalid request body. It must be a valid json object.</code>, validators like <a href="http://jsonlint.com">JSONlint</a> can save a lot of time.</p>

--- a/_parameters/facet.html
+++ b/_parameters/facet.html
@@ -36,11 +36,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -66,11 +65,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -96,11 +94,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -127,11 +124,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "facets": [
     {
       "field": "date.original",
@@ -157,11 +153,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -193,11 +188,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "facets": [
     {
       "name": "French",
@@ -241,11 +235,10 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "query":
     {
       "value": "earthquake"

--- a/_parameters/facet.html
+++ b/_parameters/facet.html
@@ -30,13 +30,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs?appname=apidoc&facets[0][field]=country&amp;facets[0][limit]=20&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&facets[0][field]=country&amp;facets[0][limit]=20&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -59,13 +59,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&facets[0][field]=country.name&amp;facets[0][sort]=count:asc&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&facets[0][field]=country.name&amp;facets[0][sort]=count:asc&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -88,13 +88,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&facets[0][field]=country.name&amp;facets[0][sort]=value:asc&amp;facets[0][limit]=5&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&facets[0][field]=country.name&amp;facets[0][sort]=value:asc&amp;facets[0][limit]=5&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -118,13 +118,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&facets[0][field]=date.original&amp;facets[0][interval]=year&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&facets[0][field]=date.original&amp;facets[0][interval]=year&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -147,13 +147,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&facets[0][field]=country&facets[0][filter][field]=theme&amp;facets[0][filter][value]=Coordination&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&facets[0][field]=country&facets[0][filter][field]=theme&amp;facets[0][filter][value]=Coordination&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -182,13 +182,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&facets[0][name]=French&amp;facets[0][filter][field]=country&amp;facets[0][filter][value]=France&amp;facets[0][field]=source&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;facets[1][name]=Spanish&amp;facets[1][filter][field]=country&amp;facets[1][filter][value]=Spain&amp;facets[1][field]=source&amp;facets[1][sort]=count:desc&amp;facets[1][limit]=5&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&facets[0][name]=French&amp;facets[0][filter][field]=country&amp;facets[0][filter][value]=France&amp;facets[0][field]=source&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;facets[1][name]=Spanish&amp;facets[1][filter][field]=country&amp;facets[1][filter][value]=Spain&amp;facets[1][field]=source&amp;facets[1][sort]=count:desc&amp;facets[1][limit]=5&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -229,13 +229,13 @@ order: 70
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&amp;query[value]=earthquake&amp;filter[field]=country&amp;filter[value]=Belgium&amp;facets[0][name]=French-global&amp;facets[0][filter][field]=country&amp;facets[0][filter][value]=France&amp;facets[0][field]=source&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;facets[0][scope]=global&amp;facets[1][name]=French-query&amp;facets[1][filter][field]=country&amp;facets[1][filter][value]=France&amp;facets[1][field]=source&amp;facets[1][sort]=count:desc&amp;facets[1][limit]=5&amp;facets[1][scope]=query&amp;facets[2][name]=French-default&amp;facets[2][filter][field]=country&amp;facets[2][filter][value]=France&amp;facets[2][field]=source&amp;facets[2][sort]=count:desc&amp;facets[2][limit]=5&amp;facets[2][scope]=default&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&amp;query[value]=earthquake&amp;filter[field]=country&amp;filter[value]=Belgium&amp;facets[0][name]=French-global&amp;facets[0][filter][field]=country&amp;facets[0][filter][value]=France&amp;facets[0][field]=source&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;facets[0][scope]=global&amp;facets[1][name]=French-query&amp;facets[1][filter][field]=country&amp;facets[1][filter][value]=France&amp;facets[1][field]=source&amp;facets[1][sort]=count:desc&amp;facets[1][limit]=5&amp;facets[1][scope]=query&amp;facets[2][name]=French-default&amp;facets[2][filter][field]=country&amp;facets[2][filter][value]=France&amp;facets[2][field]=source&amp;facets[2][sort]=count:desc&amp;facets[2][limit]=5&amp;facets[2][scope]=default&amp;limit=0</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/facet.html
+++ b/_parameters/facet.html
@@ -36,10 +36,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/jobs</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -65,10 +66,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -94,10 +96,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -124,10 +127,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "facets": [
     {
       "field": "date.original",
@@ -153,10 +157,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "facets": [
     {
       "field": "country",
@@ -188,10 +193,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "facets": [
     {
       "name": "French",
@@ -235,10 +241,11 @@ order: 70
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "query":
     {
       "value": "earthquake"

--- a/_parameters/fields.html
+++ b/_parameters/fields.html
@@ -23,13 +23,13 @@ order: 10
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&limit=3&amp;preset=latest&amp;fields[include][]=url</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&limit=3&amp;preset=latest&amp;fields[include][]=url</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -50,13 +50,13 @@ order: 10
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&limit=3&amp;preset=latest&amp;fields[exclude][]=title</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&limit=3&amp;preset=latest&amp;fields[exclude][]=title</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -77,13 +77,13 @@ order: 10
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&limit=3&amp;preset=latest&amp;profile=list&amp;fields[exclude][]=source</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&limit=3&amp;preset=latest&amp;profile=list&amp;fields[exclude][]=source</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/fields.html
+++ b/_parameters/fields.html
@@ -29,11 +29,10 @@ order: 10
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "limit": 3,
   "preset": "latest",
   "fields": {
@@ -57,11 +56,10 @@ order: 10
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "limit": 3,
   "preset": "latest",
   "fields": {
@@ -85,11 +83,10 @@ order: 10
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "limit": 3,
   "preset": "latest",
   "profile": "list",

--- a/_parameters/fields.html
+++ b/_parameters/fields.html
@@ -29,10 +29,11 @@ order: 10
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "limit": 3,
   "preset": "latest",
   "fields": {
@@ -56,10 +57,11 @@ order: 10
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "limit": 3,
   "preset": "latest",
   "fields": {
@@ -83,10 +85,11 @@ order: 10
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "limit": 3,
   "preset": "latest",
   "profile": "list",

--- a/_parameters/filter.html
+++ b/_parameters/filter.html
@@ -30,10 +30,11 @@ order: 80
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "field": "headline"
@@ -56,10 +57,11 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "field": "country",
@@ -83,10 +85,11 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "field": "country",
@@ -111,10 +114,11 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "operator": "AND",
@@ -151,10 +155,11 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "field": "date.created",
@@ -182,10 +187,11 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "operator": "AND",
@@ -217,10 +223,11 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
     {
       "operator": "OR",

--- a/_parameters/filter.html
+++ b/_parameters/filter.html
@@ -25,12 +25,12 @@ order: 80
 
     <p>GET:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=headline</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=headline</code></pre></div>
     </div>
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -50,13 +50,13 @@ order: 80
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=country&amp;filter[value]=France</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=country&amp;filter[value]=France</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -77,13 +77,13 @@ order: 80
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=country&filter[value][]=Spain&filter[value][]=France&filter[operator]=OR</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=country&filter[value][]=Spain&filter[value][]=France&filter[operator]=OR</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -105,13 +105,13 @@ order: 80
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[operator]=AND&amp;filter[conditions][0][field]=country&amp;filter[conditions][0][value][]=Spain&amp;filter[conditions][0][value][]=France&amp;filter[conditions][0][operator]=OR&amp;filter[conditions][1][field]=country&amp;filter[conditions][1][value]=Italy&amp;filter[conditions][1][negate]=true</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[operator]=AND&amp;filter[conditions][0][field]=country&amp;filter[conditions][0][value][]=Spain&amp;filter[conditions][0][value][]=France&amp;filter[conditions][0][operator]=OR&amp;filter[conditions][1][field]=country&amp;filter[conditions][1][value]=Italy&amp;filter[conditions][1][negate]=true</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -145,13 +145,13 @@ order: 80
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=date.created&amp;filter[value][from]=2004-06-01T00:00:00%2B00:00&amp;filter[value][to]=2004-06-30T23:59:59%2B00:00</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=date.created&amp;filter[value][from]=2004-06-01T00:00:00%2B00:00&amp;filter[value][to]=2004-06-30T23:59:59%2B00:00</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -176,13 +176,13 @@ order: 80
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[operator]=AND&amp;filter[conditions][0][field]=headline&amp;filter[conditions][1][field]=country&amp;filter[conditions][1][value]=France</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[operator]=AND&amp;filter[conditions][0][field]=headline&amp;filter[conditions][1][field]=country&amp;filter[conditions][1][value]=France</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -211,13 +211,13 @@ order: 80
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[operator]=OR&filter[conditions][0][operator]=AND&filter[conditions][0][conditions][0][field]=primary_country&filter[conditions][0][conditions][0][value]=Afghanistan&filter[conditions][0][conditions][1][operator]=OR&filter[conditions][0][conditions][1][field]=format&filter[conditions][0][conditions][1][value][]=Map&filter[conditions][0][conditions][1][value][]=Infographic&filter[conditions][1][field]=headline&fields[include][]=format.name&fields[include][]=primary_country.name&fields[include][]=headline.title</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[operator]=OR&filter[conditions][0][operator]=AND&filter[conditions][0][conditions][0][field]=primary_country&filter[conditions][0][conditions][0][value]=Afghanistan&filter[conditions][0][conditions][1][operator]=OR&filter[conditions][0][conditions][1][field]=format&filter[conditions][0][conditions][1][value][]=Map&filter[conditions][0][conditions][1][value][]=Infographic&filter[conditions][1][field]=headline&fields[include][]=format.name&fields[include][]=primary_country.name&fields[include][]=headline.title</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/filter.html
+++ b/_parameters/filter.html
@@ -30,11 +30,10 @@ order: 80
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "field": "headline"
@@ -57,11 +56,10 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "field": "country",
@@ -85,11 +83,10 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "field": "country",
@@ -114,11 +111,10 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "operator": "AND",
@@ -155,11 +151,10 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "field": "date.created",
@@ -187,11 +182,10 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "operator": "AND",
@@ -223,11 +217,10 @@ order: 80
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
     {
       "operator": "OR",

--- a/_parameters/limit.html
+++ b/_parameters/limit.html
@@ -20,10 +20,11 @@ order: 60
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "limit": 300
 }
 </pre>

--- a/_parameters/limit.html
+++ b/_parameters/limit.html
@@ -20,11 +20,10 @@ order: 60
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "limit": 300
 }
 </pre>

--- a/_parameters/limit.html
+++ b/_parameters/limit.html
@@ -14,13 +14,13 @@ order: 60
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc&limit=300</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&limit=300</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/offset.html
+++ b/_parameters/offset.html
@@ -20,10 +20,11 @@ order: 50
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "offset": 1000
 }
 </pre>

--- a/_parameters/offset.html
+++ b/_parameters/offset.html
@@ -14,13 +14,13 @@ order: 50
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources?appname=apidoc&offset=1000</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&offset=1000</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/offset.html
+++ b/_parameters/offset.html
@@ -20,11 +20,10 @@ order: 50
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/sources?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "offset": 1000
 }
 </pre>

--- a/_parameters/preset.html
+++ b/_parameters/preset.html
@@ -28,11 +28,10 @@ order: 20
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "preset": "latest",
   "query":
     {
@@ -60,11 +59,10 @@ order: 20
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "preset": "minimal",
   "query":
     {

--- a/_parameters/preset.html
+++ b/_parameters/preset.html
@@ -22,13 +22,13 @@ order: 20
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&preset=latest&query[value]=French&fields[include][]=language.name</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&preset=latest&query[value]=French&fields[include][]=language.name</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -53,13 +53,13 @@ order: 20
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&preset=minimal&query[value]=French&fields[include][]=language.name</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&preset=minimal&query[value]=French&fields[include][]=language.name</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/preset.html
+++ b/_parameters/preset.html
@@ -28,10 +28,11 @@ order: 20
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "preset": "latest",
   "query":
     {
@@ -59,10 +60,11 @@ order: 20
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "preset": "minimal",
   "query":
     {

--- a/_parameters/profile.html
+++ b/_parameters/profile.html
@@ -23,13 +23,13 @@ order: 30
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc&profile=list&fields[include][]=iso3</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&profile=list&fields[include][]=iso3</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/profile.html
+++ b/_parameters/profile.html
@@ -29,11 +29,10 @@ order: 30
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "profile": "list",
   "fields":
     {

--- a/_parameters/profile.html
+++ b/_parameters/profile.html
@@ -29,10 +29,11 @@ order: 30
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "profile": "list",
   "fields":
     {

--- a/_parameters/query.html
+++ b/_parameters/query.html
@@ -26,12 +26,12 @@ order: 90
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&query[value]=earthquake</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&query[value]=earthquake</code></pre></div>
     </div>
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -53,12 +53,12 @@ order: 90
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&query[value]=earthquake&query[fields][]=source&fields[include][]=source.name</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&query[value]=earthquake&query[fields][]=source&fields[include][]=source.name</code></pre></div>
     </div>
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -85,12 +85,12 @@ order: 90
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&query[fields][]=title&amp;query[value]=hot cold&amp;query[operator]=AND&amp;preset=latest</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&query[fields][]=title&amp;query[value]=hot cold&amp;query[operator]=AND&amp;preset=latest</code></pre></div>
     </div>
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -115,12 +115,12 @@ order: 90
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&amp;query[fields][]=source.shortname.exact&amp;query[value]=UN&amp;fields[include][]=source.shortname</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&amp;query[fields][]=source.shortname.exact&amp;query[value]=UN&amp;fields[include][]=source.shortname</code></pre></div>
     </div>
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/query.html
+++ b/_parameters/query.html
@@ -31,10 +31,11 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "query":
     {
       "value": "earthquake"
@@ -58,10 +59,11 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "query":
     {
       "value": "earthquake",
@@ -90,10 +92,11 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "query":
     {
       "value": "hot cold",
@@ -120,10 +123,11 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "query":
     {
       "value": "UN",

--- a/_parameters/query.html
+++ b/_parameters/query.html
@@ -31,11 +31,10 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "query":
     {
       "value": "earthquake"
@@ -59,11 +58,10 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "query":
     {
       "value": "earthquake",
@@ -92,11 +90,10 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "query":
     {
       "value": "hot cold",
@@ -123,11 +120,10 @@ order: 90
 
     <p>POST:</p>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "query":
     {
       "value": "UN",

--- a/_parameters/slim.html
+++ b/_parameters/slim.html
@@ -17,13 +17,13 @@ order: 5
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&amp;slim=1&amp;limit=2</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&amp;slim=1&amp;limit=2</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/slim.html
+++ b/_parameters/slim.html
@@ -23,11 +23,10 @@ order: 5
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "slim": 1,
   "limit": 2
 }

--- a/_parameters/slim.html
+++ b/_parameters/slim.html
@@ -23,10 +23,11 @@ order: 5
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/countries</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "slim": 1,
   "limit": 2
 }

--- a/_parameters/sort.html
+++ b/_parameters/sort.html
@@ -24,11 +24,10 @@ order: 40
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "sort": ["date:desc", "title:asc"]
 }
 </pre>

--- a/_parameters/sort.html
+++ b/_parameters/sort.html
@@ -18,13 +18,13 @@ order: 40
     <p>GET:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&sort[]=date:desc&amp;sort[]=title:asc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&sort[]=date:desc&amp;sort[]=title:asc</code></pre></div>
     </div>
 
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {

--- a/_parameters/sort.html
+++ b/_parameters/sort.html
@@ -24,10 +24,11 @@ order: 40
     <p>POST:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
       <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "sort": ["date:desc", "title:asc"]
 }
 </pre>

--- a/_parameters/verbose.html
+++ b/_parameters/verbose.html
@@ -13,7 +13,7 @@ order: 1
 <ul>
   <li>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&verbose=1&facets[0][name]=French&amp;facets[0][filter][field]=country&amp;facets[0][filter][value]=France&amp;facets[0][field]=country&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;facets[1][name]=Spanish&amp;facets[1][filter][field]=country&amp;facets[1][filter][value]=Spain&amp;facets[1][field]=country&amp;facets[1][sort]=count:desc&amp;facets[1][limit]=5&amp;limit=0</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&verbose=1&facets[0][name]=French&amp;facets[0][filter][field]=country&amp;facets[0][filter][value]=France&amp;facets[0][field]=country&amp;facets[0][sort]=count:desc&amp;facets[0][limit]=5&amp;facets[1][name]=Spanish&amp;facets[1][filter][field]=country&amp;facets[1][filter][value]=Spain&amp;facets[1][field]=country&amp;facets[1][sort]=count:desc&amp;facets[1][limit]=5&amp;limit=0</code></pre></div>
     </div>
   </li>
 </ul>

--- a/_questions/advanced-queries.html
+++ b/_questions/advanced-queries.html
@@ -13,10 +13,10 @@ order: 50
     <p>Compare:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&fields[include][]=source.name&amp;query[fields][]=title^10&amp;query[fields][]=source.name^1&amp;query[value]=climate</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&fields[include][]=source.name&amp;query[fields][]=title^10&amp;query[fields][]=source.name^1&amp;query[value]=climate</code></pre></div>
     </div>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&fields[include][]=source.name&amp;query[fields][]=title^1&amp;query[fields][]=source.name^10&amp;query[value]=climate</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&fields[include][]=source.name&amp;query[fields][]=title^1&amp;query[fields][]=source.name^10&amp;query[value]=climate</code></pre></div>
     </div>
   </li>
 
@@ -28,13 +28,13 @@ order: 50
     <p>Compare:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&sort[]=date:desc&amp;query[fields][]=title&amp;query[value]=hot AND cold&amp;query[operator]=OR</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&sort[]=date:desc&amp;query[fields][]=title&amp;query[value]=hot AND cold&amp;query[operator]=OR</code></pre></div>
     </div>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&sort[]=date:desc&amp;query[fields][]=title&amp;query[value]=hot OR cold&amp;query[operator]=OR</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&sort[]=date:desc&amp;query[fields][]=title&amp;query[value]=hot OR cold&amp;query[operator]=OR</code></pre></div>
     </div>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&sort[]=date:desc&amp;query[fields][]=title&amp;query[value]=hot NOT cold&amp;query[operator]=OR</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&sort[]=date:desc&amp;query[fields][]=title&amp;query[value]=hot NOT cold&amp;query[operator]=OR</code></pre></div>
     </div>
 
     <p><strong>Note:</strong> we added <code>sort[]=date:desc</code> to these queries to show the difference. Otherwise, as they're sorted by relevance, results of <code>AND</code> and <code>OR</code> queries can look very similar.</p>
@@ -50,10 +50,10 @@ order: 50
     <p>Compare:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&fields[include][]=source.name&amp;query[value]=title:climate</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&fields[include][]=source.name&amp;query[value]=title:climate</code></pre></div>
     </div>
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&fields[include][]=source.name&amp;query[value]=source:climate</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&fields[include][]=source.name&amp;query[value]=source:climate</code></pre></div>
     </div>
   </li>
 
@@ -62,7 +62,7 @@ order: 50
     <p>Logical groupings of search terms using parentheses give even more flexibility:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&query[value]=("situation report" AND humanitarian) OR country:France</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&query[value]=("situation report" AND humanitarian) OR country:France</code></pre></div>
     </div>
   </li>
 </ul>

--- a/_questions/exact-results.html
+++ b/_questions/exact-results.html
@@ -11,19 +11,19 @@ order: 60
 <p>All reports tagged with disasters including 'Myanmar:' or 'Earthquake' but not necessarily both at once</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=disaster.name&amp;filter[value]=Myanmar: Earthquake&fields[include][]=disaster.name</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=disaster.name&amp;filter[value]=Myanmar: Earthquake&fields[include][]=disaster.name</code></pre></div>
 </div>
 
 <p>All reports tagged with disasters including 'Myanmar: Earthquake' in their name</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=disaster.name&amp;filter[value]="Myanmar: Earthquake"&fields[include][]=disaster.name</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=disaster.name&amp;filter[value]="Myanmar: Earthquake"&fields[include][]=disaster.name</code></pre></div>
 </div>
 
 <p>The same query written as a POST request:</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
   <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -42,11 +42,11 @@ order: 60
 <p>All reports tagged with a disaster named exactly 'Myanmar: Earthquake' (there aren't any)</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=disaster.name.exact&amp;filter[value]=Myanmar: Earthquake&fields[include][]=disaster.name</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=disaster.name.exact&amp;filter[value]=Myanmar: Earthquake&fields[include][]=disaster.name</code></pre></div>
 </div>
 
 <p>All reports tagged with a disaster named exactly 'Myanmar: Earthquake - Apr 2016'</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=disaster.name.exact&amp;filter[value]=Myanmar: Earthquake - Apr 2016&fields[include][]=disaster.name</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=disaster.name.exact&amp;filter[value]=Myanmar: Earthquake - Apr 2016&fields[include][]=disaster.name</code></pre></div>
 </div>

--- a/_questions/exact-results.html
+++ b/_questions/exact-results.html
@@ -23,10 +23,11 @@ order: 60
 <p>The same query written as a POST request:</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
   <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter": {
     "field": "disaster.name",
     "value": "\"Myanmar: Earthquake\""

--- a/_questions/exact-results.html
+++ b/_questions/exact-results.html
@@ -23,11 +23,10 @@ order: 60
 <p>The same query written as a POST request:</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
   <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter": {
     "field": "disaster.name",
     "value": "\"Myanmar: Earthquake\""

--- a/_questions/post-to-get.html
+++ b/_questions/post-to-get.html
@@ -36,11 +36,10 @@ order: 30
 
 <p>Nested values can also be tricky, for example, for the <code>filter</code> parameter. Take this example from earlier:</p>
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
   <div class="post-parameters" contentEditable="true">
 <pre>
 {
-  "appname": "apidoc",
   "filter":
   {
     "operator": "AND",

--- a/_questions/post-to-get.html
+++ b/_questions/post-to-get.html
@@ -36,7 +36,7 @@ order: 30
 
 <p>Nested values can also be tricky, for example, for the <code>filter</code> parameter. Take this example from earlier:</p>
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
   <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -70,11 +70,11 @@ order: 30
 <p>So the GET query is:</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[operator]=AND&filter[conditions][0][field]=headline&filter[conditions][1][field]=country&filter[conditions][1][value][]=France</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[operator]=AND&filter[conditions][0][field]=headline&filter[conditions][1][field]=country&filter[conditions][1][value][]=France</code></pre></div>
 </div>
 
 <p>Use the <a href="/parameters#verbose"><code>verbose</code></a> parameter to check the conversion.</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&verbose=1&filter[operator]=AND&filter[conditions][0][field]=headline&filter[conditions][1][field]=country&filter[conditions][1][value][]=France</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&verbose=1&filter[operator]=AND&filter[conditions][0][field]=headline&filter[conditions][1][field]=country&filter[conditions][1][value][]=France</code></pre></div>
 </div>

--- a/_questions/post-to-get.html
+++ b/_questions/post-to-get.html
@@ -36,10 +36,11 @@ order: 30
 
 <p>Nested values can also be tricky, for example, for the <code>filter</code> parameter. Take this example from earlier:</p>
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports</code></pre></div>
   <div class="post-parameters" contentEditable="true">
 <pre>
 {
+  "appname": "apidoc",
   "filter":
   {
     "operator": "AND",

--- a/_questions/totalcount.html
+++ b/_questions/totalcount.html
@@ -9,5 +9,5 @@ order: 40
 <p>To find out how many reports have been published from IFRC, for example, look at the <code>totalCount</code> from:</p>
 
 <div class="apiCall">
-  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=source.shortname&amp;filter[value]=IFRC&amp;limit=0</code></pre></div>
+  <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=source.shortname&amp;filter[value]=IFRC&amp;limit=0</code></pre></div>
 </div>

--- a/endpoints.html
+++ b/endpoints.html
@@ -44,12 +44,12 @@ title: ReliefWeb API Endpoints
         <p>GET:</p>
 
         <div class="apiCall">
-          <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+          <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
         </div>
 
         <p>POST:</p>
         <div class="apiCall">
-          <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc</code></pre></div>
+          <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME</code></pre></div>
           <div class="post-parameters" contentEditable="true">
 <pre>
 {
@@ -77,7 +77,7 @@ title: ReliefWeb API Endpoints
         <p>GET:</p>
 
         <div class="apiCall">
-          <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports/1082221?appname=apidoc&fields[include][]=source.name</code></pre></div>
+          <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports/1082221?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&fields[include][]=source.name</code></pre></div>
         </div>
 
         <p><strong>Note: </strong>As the parameters are much easier to handle, item requests are only possible with GET requests.</p>

--- a/js/site.js
+++ b/js/site.js
@@ -97,23 +97,22 @@
       apiCall.appendChild(result);
     }
     // Check that this is going to api.reliefweb.int
-    var url = apiCall.children[0].innerText;
-    if (url.indexOf('https://api.reliefweb.int/v1') !== 0) {
+    var displayUrl = apiCall.children[0].innerText
+    var actualUrl = displayUrl.replace('REPLACE-WITH-A-DOMAIN-OR-APP-NAME', 'apidoc');
+    if (actualUrl.indexOf('https://api.reliefweb.int/v1') !== 0) {
       result.innerHTML = "<strong>Error:</strong> The call must be made to <code>https://api.reliefweb.int/v1</code>";
       return;
     }
 
     // Query the API.
-    fetch(url, options)
+    fetch(actualUrl, options)
     .then(function(response) {
       return response.json();
     })
     .then(function(json) {
-      console.log('options', options);
       var resultStatus = "success",
           reTry = "Try again (after editing the request)",
           copyType = (options.method === 'POST') ? "POST JSON" : "GET URL",
-          copyUrl = url.replace("apidoc", 'REPLACE-WITH-A-DOMAIN-OR-APP-NAME'),
           html = '<button id="hideButton-' + counter + '">Hide results</button>';
       if (json.error) {
         resultStatus = "error";
@@ -124,7 +123,7 @@
         html += '<button id="copyPostOptionsButton-' + counter + '">Copy POST request</button>';
       }
       html += '<pre class="' + resultStatus + '">';
-      html += '<code>' + JSON.stringify(json, null, '\t') + '</code>';
+      html += '<code>' + JSON.stringify(json, null, '\t').replace('apidoc', 'REPLACE-WITH-A-DOMAIN-OR-APP-NAME') + '</code>';
       html += '</pre>';
 
       // Add result.
@@ -135,7 +134,7 @@
         this.parentElement.remove();
         tryButton.innerText = tryText;
       });
-      document.getElementById("copyUrlButton-" + counter).addEventListener('click', function() {copyToClipboard(copyUrl)});
+      document.getElementById("copyUrlButton-" + counter).addEventListener('click', function() {copyToClipboard(displayUrl)});
       if (copyType == "POST JSON") {
         document.getElementById("copyPostOptionsButton-" + counter).addEventListener('click', function() {copyToClipboard(options.body)});
       }

--- a/js/site.js
+++ b/js/site.js
@@ -109,17 +109,20 @@
       return response.json();
     })
     .then(function(json) {
+      console.log('options', options);
       var resultStatus = "success",
           reTry = "Try again (after editing the request)",
           copyType = (options.method === 'POST') ? "POST JSON" : "GET URL",
-          copyText = (options.method === 'POST') ? options.body : url,
-          copyText = copyText.replace("apidoc", 'REPLACE-THIS-WITH-YOUR-EMAIL-ADDRESS'),
+          copyUrl = url.replace("apidoc", 'REPLACE-WITH-A-DOMAIN-OR-APP-NAME'),
           html = '<button id="hideButton-' + counter + '">Hide results</button>';
       if (json.error) {
         resultStatus = "error";
         reTry = 'Error: "' + json.error.message + '" Adjust request and click to try again';
       }
-      html += '<button id="copyButton-' + counter + '">Copy ' + copyType + '</button>';
+      html += '<button id="copyUrlButton-' + counter + '">Copy URL</button>';
+      if (copyType == "POST JSON") {
+        html += '<button id="copyPostOptionsButton-' + counter + '">Copy POST request</button>';
+      }
       html += '<pre class="' + resultStatus + '">';
       html += '<code>' + JSON.stringify(json, null, '\t') + '</code>';
       html += '</pre>';
@@ -132,7 +135,10 @@
         this.parentElement.remove();
         tryButton.innerText = tryText;
       });
-      document.getElementById("copyButton-" + counter).addEventListener('click', function() {copyToClipboard(copyText)});
+      document.getElementById("copyUrlButton-" + counter).addEventListener('click', function() {copyToClipboard(copyUrl)});
+      if (copyType == "POST JSON") {
+        document.getElementById("copyPostOptionsButton-" + counter).addEventListener('click', function() {copyToClipboard(options.body)});
+      }
 
       // Change the try text.
       tryButton.innerText = reTry;

--- a/js/site.js
+++ b/js/site.js
@@ -113,6 +113,7 @@
           reTry = "Try again (after editing the request)",
           copyType = (options.method === 'POST') ? "POST JSON" : "GET URL",
           copyText = (options.method === 'POST') ? options.body : url,
+          copyText = copyText.replace("apidoc", 'REPLACE-THIS-WITH-YOUR-EMAIL-ADDRESS'),
           html = '<button id="hideButton-' + counter + '">Hide results</button>';
       if (json.error) {
         resultStatus = "error";

--- a/result-structure.html
+++ b/result-structure.html
@@ -38,7 +38,7 @@ title: ReliefWeb API Result structure
     <p>Query:</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&amp;profile=full&amp;limit=1</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&amp;profile=full&amp;limit=1</code></pre></div>
     </div>
 
   </li>
@@ -55,7 +55,7 @@ title: ReliefWeb API Result structure
     <p>In the example, change <code>5000</code> to fix this.</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&limit=5000</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&limit=5000</code></pre></div>
     </div>
   </li>
   <li>
@@ -64,7 +64,7 @@ title: ReliefWeb API Result structure
     <p>In this example, the date field is non url-encoded. To fix it, replace the <code>+</code> sign to <code>%2B</code>.</p>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&filter[field]=date.created&amp;filter[value][from]=2004-06-01T00:00:00+00:00</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&filter[field]=date.created&amp;filter[value][from]=2004-06-01T00:00:00+00:00</code></pre></div>
     </div>
   </li>
   <li>
@@ -77,7 +77,7 @@ title: ReliefWeb API Result structure
     </ul>
 
     <div class="apiCall">
-      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=apidoc&query[field]=country&amp;query[value]=France</code></pre></div>
+      <div class="url" contentEditable="true"><pre><code>https://api.reliefweb.int/v1/reports?appname=REPLACE-WITH-A-DOMAIN-OR-APP-NAME&query[field]=country&amp;query[value]=France</code></pre></div>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
Refs: RW-839

The main change here is in the copy functionality, which swaps 'apidoc' for 'REPLACE-THIS-WITH-YOUR-EMAIL-ADDRESS' - suggestions welcome for a better string here. If we make it something that no one would be using now, we could get the API to reject any requests with that parameter.

Wondering too whether we could use the same string in the search converter for anonymous users instead of `rwint-0`

The other major change is the paragraph in `_meta/api-use.html`. I don't know if this is sufficiently loud to make a difference. 

The other changes are small but noisy: changing the sppname parameter in post requests from part of the url to part of the json. I think it might make things more clear, but I'm in two minds.

Suggestions welcome!