### PR TITLE
update: first mention of publishing API and small bits of tidying up.

### DIFF
--- a/_meta/introduction.html
+++ b/_meta/introduction.html
@@ -4,8 +4,10 @@ title: Introduction
 order: 100
 ---
 
-<p>The ReliefWeb API was built to power a <a href="https://m.reliefweb.int">mobile/ low-bandwidth version</a> of the ReliefWeb website. Since then it has been enhanced for a public release to provide access to ReliefWeb's curated and continuously updated data archive. It's now used to serve much of the main site, selected content on other OCHA sites, and third party apps.</p>
+<p>The ReliefWeb API was originally built to power a mobile/ low-bandwidth version of the ReliefWeb website. Enhancements and a public release provided access to ReliefWeb's curated and continuously updated data archive. It's now used to serve much of the main site, content on other OCHA sites, and third party apps.</p>
 
-<p>All the content of ReliefWeb is available through its API. The API is built to fit with current API best-practices, and is intended to be friendly to developers, as well as machines. It is publicly accessible using HTTP requests and returns JSON data.</p>
+<p>All the content of ReliefWeb is available through its API. The API aligns with current API best-practices, and is intended to be friendly to developers, as well as machines. It is publicly accessible using HTTP requests and returns JSON data.</p>
 
-<p>Understanding the structure of ReliefWeb's content will help in understanding how the API works, so these documents are intended to make both as clear as possible. For clarification or to suggest improvements, please <a href="https://reliefweb.int/contact">contact</a> us.</p>
+<p>Understanding the structure of ReliefWeb's content will help in understanding how the API works. For clarification or to suggest improvements, please <a href="https://reliefweb.int/contact">contact</a> us.</p>
+
+<p>The ReliefWeb Publishing API is now in testing. If your organization is listed on <a href="https://reliefweb.int/organizations">https://reliefweb.int/organizations</a>, please <a href="https://reliefweb.int/contact">contact</a> us to obtain an API key.</p>

--- a/_meta/quickstart.html
+++ b/_meta/quickstart.html
@@ -10,4 +10,4 @@ order: 90
 
 <p>Use the filters and the search bar to refine the query.</p>
 
-<p>At the end of the page, below the pager, the <strong>API</strong> link will launch the <a href="https://reliefweb.int/search/converter">search converter</a> tool to transform the url into an API query, showing both the GET URL and the JSON payload for a POST request.</p>
+<p>At the end of the page, below the pager, the <strong>API</strong> link will launch the <a href="https://reliefweb.int/search/converter">search converter</a> tool to transform the url into an API query, showing both the GET URL and the JSON and PHP payloads for a POST request.</p>

--- a/_meta/versions.html
+++ b/_meta/versions.html
@@ -4,4 +4,6 @@ title: Versions
 order: 80
 ---
 
-<p>The current version is version 1, abbreviated as <code>v1</code>. The <a href="/v0/index.html">previous version</a>, <code>v0</code>, is deprecated and should no longer be used.</p>
+<p>The current version is <code>v1</code>. The <a href="/v0/index.html">previous version</a>, <code>v0</code>, is deprecated and should no longer be used.</p>
+
+<p>A new version, <code>v2</code> is in testing at the moment. This will include PUT requests for content providers. The appname parameter will be mandatory.</p>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title: Reliefweb API - Documentation
 
 <h1>All about the ReliefWeb API</h1>
 
-<p><strong>TL/DR</strong>: Most of the information is on the <a href="/parameters">parameters</a> page. Find an example request that resembles the one you'd like to make, edit it in place and check the results from the API (requires javascript).</p>
+<p><strong>TL/DR</strong>: To jump straight in, read the <a href="#quickstart">Quickstart</a> section. For more complex requests, most of the information is on the <a href="/parameters">parameters</a> page. Find an example request that resembles the one you'd like to make, edit it in place and check the results from the API (requires javascript).</p>
 
 <p>Jump to sections:</p>
 <ol id="cd-toc" class="cd-toc__list flex">


### PR DESCRIPTION
Refs: RW-1130

Some minor alterations including a teaser for the Publishing API
```
<p>The ReliefWeb Publishing API is now in testing. If your organization is listed on <a href="https://reliefweb.int/organizations">https://reliefweb.int/organizations</a>, please <a href="https://reliefweb.int/contact">contact</a> us to obtain an API key.</p>
```
